### PR TITLE
Taking into account Geiger hits with NaN radii

### DIFF
--- a/SNFitterModule.cpp
+++ b/SNFitterModule.cpp
@@ -130,7 +130,7 @@ FALAISE_REGISTER_MODULE(SNFitterModule)
             rings.emplace_back(TrackerHit{ncl, ring, mi});
 	}
       }
-      std::cout<<"***** NaN vec length: "<<rings.size()<<std::endl;
+      
       // ready to fit
       SNFitter snf{rings};
       std::vector<HelixFit> hres = snf.fithelix();

--- a/SNFitterModule.cpp
+++ b/SNFitterModule.cpp
@@ -122,13 +122,15 @@ FALAISE_REGISTER_MODULE(SNFitterModule)
 
       for (const auto &hit : gg_hits_col) {
         // work with geiger hits as members of a given cluster
-        GeigerRing ring{hit->get_r(), hit->get_x(),       hit->get_y(),
+	if ( !std::isnan(hit->get_r()) ){ //take into account NaN radii: discard them
+            GeigerRing ring{hit->get_r(), hit->get_x(), hit->get_y(),
                         hit->get_z(), hit->get_sigma_r(), hit->get_sigma_z()};
-        MetaInfo mi{hit->get_id(), hit->get_side(), hit->get_row(), hit->get_layer()};
+            MetaInfo mi{hit->get_id(), hit->get_side(), hit->get_row(), hit->get_layer()};
 
-        rings.emplace_back(TrackerHit{ncl, ring, mi});
+            rings.emplace_back(TrackerHit{ncl, ring, mi});
+	}
       }
-
+      std::cout<<"***** NaN vec length: "<<rings.size()<<std::endl;
       // ready to fit
       SNFitter snf{rings};
       std::vector<HelixFit> hres = snf.fithelix();


### PR DESCRIPTION
Hi Yorck,

this is a very first attempt to take into account Geiger hits with NaN radii. I went for the most conservative approach, i.e. simply discarding them. I ran and tested it, and it seems to work fine.
However, I can think of a couple of issues that might arise from discarding hits with NaN radii:

- the "number of gg hits" is equal to `gg_hits_col.size()` and memory is reserved to the vector "rings" accordingly (`rings.reserve(gg_hits_col.size()`). Could discarding hits raise memory issues in C++? (I guess it shouldn't, as we're reserving a bit more memory than needed in such cases, but C++ always amazes me. Also it might be a bit inefficient in principle, but it seems NaN radii are not that common)

- in my test sample, there was a cluster of 2 hits, but one had NaN radius so it was discarded. This raised the following errors, as one might expect:
 ```
 Error in <TDecompChol::Decompose()>: matrix not positive definite
 Error in <TDecompChol::Solve()>: Decomposition failed
 Error in <TLinearFitter::Eval>: Matrix inversion failed
 ``` 
But then the code proceeded to compute the fits with no apparent issue.

Would this fix be ok, or would it be safer to create a `&gg_hits_col` object discarding NaN radii from the very beginning?

Cheers,
Matteo